### PR TITLE
Refurbished role for one or multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,56 @@
-# ansible-dkim
-Ansible role for opendkim with postfix configuration on ubuntu
+Opendkim Ansible role
+============================
 
-### Example playbook
-```yaml
----
-- hosts: myserver
-  user: root
-  sudo: False
-  roles:
-    - role: sunfoxcz.dkim
-      dkim_selector: mail
-      dkim_domains:
-       - domain1.tld
-       - domain2.tld
-```
+This role, Opendkim, installs and configures opendkim and postfix on Debian .
+
+It works on Debian Stretch. It should work on Ubuntu or other Debian-based systems.
+
+Description
+------------
+
+This role creates a dkim key for each host hosted on the server.
+- install and configure opendkim,
+- create the keys of the domains declared in the dkim_domains variable
+- install and configure postfix
+
+Requirements
+------------
+
+This role does not require prior installation, it only has a Debian or Ubuntu system
+
+Note
+----
+
+This role is based on [FoxyRoles/ansible-dkim](https://github.com/FoxyRoles/ansible-dkim) role
+
+Role Variables
+--------------
+
+### Client vars
+
+Each client configuration overrides global configuration. Thew following variables can be defined:
+
+- `dkim_create`: true or false (default: true). If true, configures the opendkin and create or replace keys present, else install opendkim and configure postfix.
+`dkim_selector`: use that will be given to the key (default: email)
+`dkim_admin_email`: administrator email (default: example@domain.com)
+`dkim_domains`:  Domains for which keys must be created
+  - domain1.tld
+  - domain2.tld
+  - domain3.tld
+
+Example Playbook
+----------------
+
+### Quick and dirty
+
+You should look at [defaults/main.yml](defaults/main.yml).
+
+License
+-------
+
+GPLv3
+
+Author Information
+------------------
+
+Original role [Tomáš Jacík](https://github.com/foxycode) enhanced by [Víctor Torterola](https://github.com/UdelaRInterior)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+dkim_create: true
+dkim_selector: email
+dkim_admin_email: example@domain.com
+dkim_domains:
+  - domain1.com
+  - domain2.com
+  - domain3.com

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: restart opendkim
-  service: name=opendkim state=restarted
+  service: 
+    name: opendkim 
+    state: restarted
 
 - name: restart postfix
-  service: name=postfix state=restarted
+  service: 
+    name: postfix 
+    state: restarted

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -16,40 +16,63 @@
    - restart opendkim
 
 - name: opendkim directory present
-  file: path=/etc/opendkim/keys state=directory
+  file:
+    path: /etc/opendkim/keys
+    state: directory
 
 - name: opendkim TrustedHosts present
-  copy: src=TrustedHosts dest=/etc/opendkim/TrustedHosts
+  copy:
+    src: TrustedHosts
+    dest: /etc/opendkim/TrustedHosts
   notify:
    - restart opendkim
 
 - name: opendkim is configured
-  template: src=opendkim.conf.j2 dest=/etc/opendkim.conf
+  template:
+    src: opendkim.conf.j2
+    dest: /etc/opendkim.conf
   notify:
    - restart opendkim
 
 - name: opendkim KeyTable is configured
-  template: src=KeyTable.j2 dest=/etc/opendkim/KeyTable
+  template:
+    src: KeyTable.j2
+    dest: /etc/opendkim/KeyTable
   notify:
    - restart opendkim
 
 - name: opendkim SigningTable is configured
-  template: src=SigningTable.j2 dest=/etc/opendkim/SigningTable
+  template:
+    src: SigningTable.j2
+    dest: /etc/opendkim/SigningTable
   notify:
    - restart opendkim
 
-- name: ensure signing key is present
-  stat: path=/etc/opendkim/keys/{{ dkim_selector }}.private get_md5=no
-  register: dkim_key
+- name: create directory from keys
+  file:
+    path: /etc/opendkim/keys/{{ item }}
+    state: directory
+  with_items: '{{ dkim_domains }}'
+  when: dkim_create
 
 - name: generate signing key
-  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domains[0] }} -D /etc/opendkim/keys
-  when: not dkim_key.stat.exists
+  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ item }} -D /etc/opendkim/keys/{{ item }}
+  with_items: '{{ dkim_domains }}'
+  when: dkim_create
   notify:
    - restart opendkim
 
 - name: ensure signing key owner
-  file: path=/etc/opendkim/keys/{{ dkim_selector }}.private owner=opendkim group=opendkim
+  file:
+    path: /etc/opendkim/keys/{{ item }}/{{ dkim_selector }}.private
+    owner: opendkim
+    group: opendkim
+  with_items: '{{ dkim_domains }}'
 
-- name: opendkim is running
-  service: name=opendkim state=started enabled=yes
+- name: Recursively change ownership of a directory
+  file:
+    path: /etc/opendkim
+    state: directory
+    recurse: yes
+    owner: opendkim
+    group: opendkim

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -7,25 +7,33 @@
   tags: postfix
 
 - name: postfix milter_protocol is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^milter_protocol line="milter_protocol = 6"
+  lineinfile: 
+    dest: /etc/postfix/main.cf 
+    regexp: ^milter_protocol 
+    line: "milter_protocol = 6"
   notify:
    - restart postfix
 
 - name: postfix milter_default_action is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^milter_default_action line="milter_default_action = accept"
+  lineinfile: 
+    dest: /etc/postfix/main.cf 
+    regexp: ^milter_default_action 
+    line: "milter_default_action = accept"
   notify:
    - restart postfix
 
 - name: postfix smtpd_milters is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^smtpd_milters line="smtpd_milters = inet:localhost:12301"
+  lineinfile: 
+    dest: /etc/postfix/main.cf 
+    regexp: ^smtpd_milters 
+    line: "smtpd_milters = inet:localhost:12301"
   notify:
    - restart postfix
 
 - name: postfix non_smtpd_milters is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^non_smtpd_milters line="non_smtpd_milters = inet:localhost:12301"
+  lineinfile: 
+    dest: /etc/postfix/main.cf 
+    regexp: ^non_smtpd_milters 
+    line: "non_smtpd_milters = inet:localhost:12301"
   notify:
    - restart postfix
-
-- name: postfix is running
-  service: name=postfix state=started enabled=yes
-  tags: postfix

--- a/templates/KeyTable.j2
+++ b/templates/KeyTable.j2
@@ -1,3 +1,3 @@
 {% for domain in dkim_domains %}
-{{ dkim_selector }}._domainkey.{{ domain }} {{ domain }}:{{ dkim_selector }}:/etc/opendkim/keys/{{ dkim_selector }}.private
+{{ dkim_selector }}._domainkey.{{ domain }} {{ domain }}:{{ dkim_selector }}:/etc/opendkim/keys/{{ domain }}/{{ dkim_selector }}.private
 {% endfor %}

--- a/templates/opendkim.conf.j2
+++ b/templates/opendkim.conf.j2
@@ -4,7 +4,7 @@ UMask                   002
 Syslog                  yes
 SyslogSuccess           Yes
 LogWhy                  Yes
-ReportAddress           {{ admin_email }}
+ReportAddress           {{ dkim_admin_email }}
 
 Canonicalization        relaxed/simple
 


### PR DESCRIPTION
Hi Tomas. I wanted to propose some changes that meet the functionality I had but add others.
The role now creates certificates for one or more domains.
The default variables in "default.yml" are added to the role structure.
Readme file is updated.
Task structure change:
````
- name: create directory from keys
  file: path=/etc/opendkim/keys/{{ item }} state=directory
  with_items: '{{ dkim_domains }}'
  when: dkim_create
````
now
````
- name: create directory from keys
  file:
    path: /etc/opendkim/keys/{{ item }}
    state: directory
  with_items: '{{ dkim_domains }}'
  when: dkim_create
````
In this way all tasks are modified