### PR TITLE
Manage one key per domain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,14 @@
 ---
 ## Default Variables for ansible-dkim role
 
-
 ## The "selector" for opendkim keys and DNS records generation
 dkim_selector: email
 
 ## The e-mail address that manages opendkim
-dkim_admin_email: example@domain.tld
+dkim_admin_email: "{{ admin_email | default ( 'example@domain.tld' ) }}"
+# This variable, in the role's namespace `dkim_` is defined with the value of `admin_email` for backward
+# compatibility of the role, and to eventually harmonise this value accross a whole set of roles. 
+# In your playbooks, you can set either `dkim_admin_email` or `admin_email`
 
 ## The list of domains you want opendkim to sign mails for
 dkim_domains:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,16 +5,16 @@
 dkim_selector: email
 
 ## The e-mail address that manages opendkim
-dkim_admin_email: "{{ admin_email | default ( 'example@domain.tld' ) }}"
-# This variable, in the role's namespace `dkim_` is defined with the value of `admin_email` for backward
-# compatibility of the role, and to eventually harmonise this value accross a whole set of roles. 
-# In your playbooks, you can set either `dkim_admin_email` or `admin_email`
+dkim_admin_email: "{{ admin_email | default ( omit ) }}"
+# This variable, in the role's namespace `dkim_`, is defined with the value of `admin_email` for backward
+# compatibility of the role, and eventually to harmonise this value accross a whole set of roles. 
+# In your playbooks, you MUST set either `dkim_admin_email` or `admin_email`
 
-## The list of domains you want opendkim to sign mails for
-dkim_domains:
-  - domain1.tld
-  - domain2.tld
-  - domain3.tld
+## The list of domains you want opendkim to sign mails for MUST be defined as a list:
+# dkim_domains:
+#   - domain1.tld
+#   - domain2.tld
+#   - domain3.tld
 
 ## Whether opendkim uses the same key for all domains or one key per domain
 dkim_same_key: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+## Default Variables for ansible-dkim role
+
+
+## The "selector" for opendkim keys and DNS records generation
+dkim_selector: email
+
+## The e-mail address that manages opendkim
+dkim_admin_email: example@domain.tld
+
+## The list of domains you want opendkim to sign mails for
+dkim_domains:
+  - domain1.tld
+  - domain2.tld
+  - domain3.tld
+
+## Whether opendkim uses the same key for all domains or one key per domain
+dkim_same_key: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: restart opendkim
   service: name=opendkim state=restarted
 
-- name: restart postfix
+- name: opendkim - restart postfix
   service: name=postfix state=restarted

--- a/tasks/dns_records.yml
+++ b/tasks/dns_records.yml
@@ -1,0 +1,25 @@
+---
+## Show the DNS records to configure with dkim publik key
+
+- name: find files with DNS records with public keys
+  find:
+    path: /etc/opendkim/keys
+    patterns: '{{ dkim_selector }}.txt'
+    recurse: yes
+  register: dkim_txt_files
+
+- name: extract found files content
+  slurp:
+    src: '{{ dkim_txt_file.path }}'
+  loop: '{{ dkim_txt_files.files }}'
+  loop_control:
+    loop_var: dkim_txt_file
+  register: dkim_dns_records
+
+- name: show DNS records in dkim_selector.txt files
+  debug: 
+    msg: 
+    - 'You must add to your DNS the following records:'
+    - "{{ dkim_dns_records.results | json_query ('[*].content') | map('b64decode') | list  }}"
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,18 @@
 ---
+## Tasks for Opendkim Ansible role
+
+- fail:
+    msg: "Bailing out. This role requires 'dkim_admin_email' to have an email address as value"
+  when: dkim_admin_email is not defined
+
+- fail:
+    msg: "Bailing out. This role requires 'dkim_domains' to be defined as a list of domains."
+  when: 
+  - dkim_domains is not defined
+  - dkim_domains is not list
 
 - import_tasks: opendkim.yml
+
 - import_tasks: postfix.yml
+
 - import_tasks: dns_records.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 ## Tasks for Opendkim Ansible role
 
 - fail:
-    msg: "Bailing out. This role requires 'dkim_admin_email' to have an email address as value"
+    msg: "bailing out, this role requires either 'dkim_admin_email' or `admin_email` to have an email address as value"
   when: dkim_admin_email is not defined
 
 - fail:
-    msg: "Bailing out. This role requires 'dkim_domains' to be defined as a list of domains."
+    msg: "bailing out, this role requires 'dkim_domains' to be defined as a list of domains."
   when: 
   - dkim_domains is not defined
   - dkim_domains is not list

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,3 +2,4 @@
 
 - import_tasks: opendkim.yml
 - import_tasks: postfix.yml
+- import_tasks: dns_records.yml

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -38,18 +38,11 @@
   notify:
    - restart opendkim
 
-- name: ensure signing key is present
-  stat: path=/etc/opendkim/keys/{{ dkim_selector }}.private get_md5=no
-  register: dkim_key
-
-- name: generate signing key
-  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domains[0] }} -D /etc/opendkim/keys
-  when: not dkim_key.stat.exists
-  notify:
-   - restart opendkim
-
-- name: ensure signing key owner
-  file: path=/etc/opendkim/keys/{{ dkim_selector }}.private owner=opendkim group=opendkim
+- name: generate opendkim keys
+  include_tasks: opendkim_keys.yml 
+  loop: '{{ [ dkim_domains[0] ] if dkim_same_key else dkim_domains }}'
+  loop_control:
+    loop_var: domain
 
 - name: opendkim is running
   service: name=opendkim state=started enabled=yes

--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -1,0 +1,26 @@
+---
+## Loop to generate keys for each domain
+- name: creates domain's keys directory
+  file: 
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}
+    state: directory
+
+- name: ensure signing key is present
+  stat: 
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}/{{ dkim_selector }}.private
+    get_md5: no
+  register: dkim_key
+
+- name: generate signing key
+  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ domain }} -D /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}
+  when: not dkim_key.stat.exists
+  notify:
+  - restart opendkim
+
+- name: ensure signing key owner
+  file:
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}/{{ dkim_selector }}.private
+    owner: opendkim 
+    group: opendkim
+
+...

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -9,22 +9,22 @@
 - name: postfix milter_protocol is configured
   lineinfile: dest=/etc/postfix/main.cf regexp=^milter_protocol line="milter_protocol = 6"
   notify:
-   - restart postfix
+   - opendkim - restart postfix
 
 - name: postfix milter_default_action is configured
   lineinfile: dest=/etc/postfix/main.cf regexp=^milter_default_action line="milter_default_action = accept"
   notify:
-   - restart postfix
+   - opendkim - restart postfix
 
 - name: postfix smtpd_milters is configured
   lineinfile: dest=/etc/postfix/main.cf regexp=^smtpd_milters line="smtpd_milters = inet:localhost:12301"
   notify:
-   - restart postfix
+   - opendkim - restart postfix
 
 - name: postfix non_smtpd_milters is configured
   lineinfile: dest=/etc/postfix/main.cf regexp=^non_smtpd_milters line="non_smtpd_milters = inet:localhost:12301"
   notify:
-   - restart postfix
+   - opendkim - restart postfix
 
 - name: postfix is running
   service: name=postfix state=started enabled=yes

--- a/templates/KeyTable.j2
+++ b/templates/KeyTable.j2
@@ -1,3 +1,3 @@
 {% for domain in dkim_domains %}
-{{ dkim_selector }}._domainkey.{{ domain }} {{ domain }}:{{ dkim_selector }}:/etc/opendkim/keys/{{ dkim_selector }}.private
+{{ dkim_selector }}._domainkey.{{ domain }} {{ domain }}:{{ dkim_selector }}:/etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}/{{ dkim_selector }}.private
 {% endfor %}

--- a/templates/opendkim.conf.j2
+++ b/templates/opendkim.conf.j2
@@ -4,7 +4,7 @@ UMask                   002
 Syslog                  yes
 SyslogSuccess           Yes
 LogWhy                  Yes
-ReportAddress           {{ admin_email }}
+ReportAddress           {{ dkim_admin_email }}
 
 Canonicalization        relaxed/simple
 


### PR DESCRIPTION
Hello. 
In this PR I propose you an evolution of your role, adding:
- an option to manage one key per domain and not only always the same key for all configured domains,
- a print on screen on Ansible controller of DNS records with public keys that you must add. 

We would be glad to work on this role (some documnentation, keys reset, ...) and publish it in [Ansible Galaxy](https://galaxy.ansible.com). As we started with a fork of your role, we considered the fair way is to propose you to do it with your original role.   