### PR TITLE
for PR, no use of json_query filter and better output of DNS records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+meta/.galaxy_install_info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog od ansible-dkim role
+
+##  [v1.1.0](https://github.com/FoxyRoles/ansible-dkim/releases/tag/v1.1.0) by [@ulvida](https://github.com/ulvida)
+* Option tu sign all the domains with the same key or each domain with its own key,
+* DNS records with DKIM public keys to be configured in the public DNS for each domain we sign the mails for are shown at the end of the playbook,
+* parametrisation of several values in the playbook previously hard-coded.
+
+##  [v1.0.0](https://github.com/FoxyRoles/ansible-dkim/releases/tag/v1.0.0) by [@foxycode](https://github.com/foxycode)
+
+* first released version
+* configuration of opendkim to sign mails for a list of domains as a milter of postfix
+* uso of the same key for all domains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog od ansible-dkim role
 
 ##  [v1.1.0](https://github.com/FoxyRoles/ansible-dkim/releases/tag/v1.1.0) by [@ulvida](https://github.com/ulvida)
-* Option tu sign all the domains with the same key or each domain with its own key,
-* DNS records with DKIM public keys to be configured in the public DNS for each domain we sign the mails for are shown at the end of the playbook,
-* parametrisation of several values in the playbook previously hard-coded.
+* Option to sign all the domains with the same key or each domain with its own key,
+* DNS records with DKIM public keys to be configured in the public DNS for each domain we sign the mails for, are shown at the end of the playbook,
+* Parametrisation of several values in the playbook previously hard-coded.
 
 ##  [v1.0.0](https://github.com/FoxyRoles/ansible-dkim/releases/tag/v1.0.0) by [@foxycode](https://github.com/foxycode)
 
-* first released version
-* configuration of opendkim to sign mails for a list of domains as a milter of postfix
-* use of the same key for all domains
+* First released version
+* Configuration of Opendkim to sign mails for a list of domains as a milter of postfix
+* Use of the same key for all domains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@
 
 * first released version
 * configuration of opendkim to sign mails for a list of domains as a milter of postfix
-* uso of the same key for all domains
+* use of the same key for all domains

--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@ Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](
 
 ## Description
 
-This role confiures DKIM mail singing service in a hosts that works as e.ail MTA. 
+This role confiures DKIM mail singing service in a hosts that works as an e-mail MTA. 
 
 The role: 
 * installs and configures opendkim,
 * creates private and public dkim keys for the domains it has to sign, declared in the `dkim_domains` variable,
-* installs postfix and configures it to pass all the messages of the configured domains to be signed by OpenDKIM,
+* installs postfix and configures it to pass all the messages of the configured domains to be signed by opendkim,
 * shows the DNS records with the public keys that must be defined in the public DNS of the domains we sign.
 
 ## Requirements
 
-The role requires that you configure all the rest of the mail management and you will need to have access to the DNS configuration of the domains you are requiesting to sign. At the end, the role will give you the DNS records with the public keys of the domain that you will have to publish in the global DNS system.  
+The role requires that you configure all the rest of the mail management and you will need to have access to the DNS configuration of the domains you are requiesting to sign. At the end, the role will give you the DNS records with the public keys of the domains that you will have to publish in the global DNS system.  
 
 ## Role variable
+
+See also comments and default values in role's file `default/main.yml`.
 
 ### Opendkim package parameters
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,50 @@
 # ansible-dkim
 
-Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](http://opendkim.org/) support on [Ubuntu](https://ubuntu.com/).
+Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](http://opendkim.org/). Works on [Debian](https://debian.org) distributions and derived like [Ubuntu](https://ubuntu.com/).
 
-### Example playbook
+## Description
+
+This role confiures DKIM mail singing service in a hosts that works as e.ail MTA. 
+
+The role: 
+* installs and configures opendkim,
+* creates private and public dkim keys for the domains it has to sign, declared in the `dkim_domains` variable,
+* installs postfix and configures it to pass all the messages of the configured domains to be signed by OpenDKIM,
+* shows the DNS records with the public keys that must be defined in the public DNS of the domains we sign.
+
+## Requirements
+
+The role requires that you configure all the rest of the mail management and you will need to have access to the DNS configuration of the domains you are requiesting to sign. At the end, the role will give you the DNS records with the public keys of the domain that you will have to publish in the global DNS system.  
+
+## Role variable
+
+### Opendkim package parameters
+
+|  Variable     |   Default value   |   Description  |
+|:-------------------:|:------------------------:|:------------:|
+| `dkim_default_config_file:` | /etc/default/opendkim | Opendkim Default values configuration file |
+| `dkim_opendkim_config:` | /etc/opendkim | Opendkim configuration folder |
+| `dkim_user:` | opendkim | linux user that runs Opendkim | 
+| `dkim_group:` | opendkim | linux group that runs Opendkim | 
+
+### Opendkim configuration parameters
+
+|  Variable     |   Default value   |   Description  |
+|:-------------------:|:------------------------:|:------------:|
+| `dkim_selector:` | email | Opendkim registers' selector |
+| `dkim_admin_email:` | none | e-mail address that manages opendkim. You musrt define either `dkim_admin_email` or legacy `admin_email`. |
+| `dkim_domains:` | none | List of domains that opendkim must be configured to sign the mails of. A yaml list of DNS. |
+| `dkim_same_key:` | true | Whether opendkim must use the same keys for all domains or a set of keys for each domain.  |
+| `dkim_dns_record_pause:` | 0 | The time (seconds) the role will pause to show the DNS records with the public keys that must be configured.  |
+
+### Postfix configuration variables 
+
+  Variable     |   Default value   |   Description  |
+|:-------------------:|:------------------------:|:------------:|
+| `dkim_postfix_config_file:` | /etc/postfix/main.cf | Postfix main configuration file. |
+| `dkim_postfix_config:` | see `vars/main.yml` | list of parameters to be defined in postfix configuration. Default configuration ensures opendkim is set up as a milter of post fix to sign mails. You can define additional postfix parameters using a list union. |
+
+## Example playbook
 ```yaml
 ---
 - hosts: myserver
@@ -14,6 +56,7 @@ Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](
       dkim_domains:
        - domain1.tld
        - domain2.tld
+      dkim_same_key: false
 ```
 
 ### License

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See also comments and default values in role's file [`default/main.yml`](default
 
 |  Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|
-| `dkim_selector:` | email | Opendkim DNS registers' selector. It can be modified if several DKIM DNS records have to be defined for the same domain.  |
+| `dkim_selector:` | email | DKIM Public Key DNS record's selector. The definition of a value specific to the MTA server allows to associate the same domain several DKIM Public Keys as DNS records, one for each server that manages and signs mail of the domain.  |
 | `dkim_admin_email:` | none | e-mail address that manages Opendkim. You must define either `dkim_admin_email` or legacy `admin_email`. |
 | `dkim_domains:` | none | List of domains that Opendkim must be configured to sign the mails of. A yaml list of DNS. |
 | `dkim_same_key:` | true | Whether Opendkim must generate and use the same key for all domains or one specific key for each domain.  |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ansible-dkim
 
-Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](http://opendkim.org/). Works on [Debian](https://debian.org) distributions and derived like [Ubuntu](https://ubuntu.com/).
+Ansible role for configuring [Postfix](http://www.postfix.org/) with [OpenDKIM](http://opendkim.org/), an implementation for Linux of [DKIM mail signing](http://dkim.org/). Works on [Debian](https://debian.org) distributions and derived like [Ubuntu](https://ubuntu.com/).
 
 ## Description
 
-This role confiures DKIM mail singing service in a hosts that works as an e-mail MTA. 
+This role configures DKIM mail signing service in a hosts that works as a Mail Transport Agent (MTA). 
 
 The role: 
 * installs and configures opendkim,
@@ -14,18 +14,18 @@ The role:
 
 ## Requirements
 
-The role requires that you configure all the rest of the mail management and you will need to have access to the DNS configuration of the domains you are requiesting to sign. At the end, the role will give you the DNS records with the public keys of the domains that you will have to publish in the global DNS system.  
+The role requires that you configure all the rest of the mail management and you will need to have access to the DNS configuration of the domains you are requesting to sign. At the end, the role will give you the DNS records with the public keys of the domains that you will have to publish in the global DNS system.
 
 ## Role variable
 
-See also comments and default values in role's file `default/main.yml`.
+See also comments and default values in role's file [`default/main.yml`](default/main.yml).
 
 ### Opendkim package parameters
 
 |  Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|
-| `dkim_default_config_file:` | /etc/default/opendkim | Opendkim Default values configuration file |
-| `dkim_opendkim_config:` | /etc/opendkim | Opendkim configuration folder |
+| `dkim_default_config_file:` | /etc/default/opendkim | Opendkim default values configuration file |
+| `dkim_opendkim_config_dir:` | /etc/opendkim | Opendkim configuration directory |
 | `dkim_user:` | opendkim | linux user that runs Opendkim | 
 | `dkim_group:` | opendkim | linux group that runs Opendkim | 
 
@@ -33,18 +33,18 @@ See also comments and default values in role's file `default/main.yml`.
 
 |  Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|
-| `dkim_selector:` | email | Opendkim registers' selector |
-| `dkim_admin_email:` | none | e-mail address that manages opendkim. You musrt define either `dkim_admin_email` or legacy `admin_email`. |
-| `dkim_domains:` | none | List of domains that opendkim must be configured to sign the mails of. A yaml list of DNS. |
-| `dkim_same_key:` | true | Whether opendkim must use the same keys for all domains or a set of keys for each domain.  |
-| `dkim_dns_record_pause:` | 0 | The time (seconds) the role will pause to show the DNS records with the public keys that must be configured.  |
+| `dkim_selector:` | email | Opendkim DNS registers' selector. It can be modified if several DKIM DNS records have to be defined for the same domain.  |
+| `dkim_admin_email:` | none | e-mail address that manages Opendkim. You must define either `dkim_admin_email` or legacy `admin_email`. |
+| `dkim_domains:` | none | List of domains that Opendkim must be configured to sign the mails of. A yaml list of DNS. |
+| `dkim_same_key:` | true | Whether Opendkim must generate and use the same key for all domains or one specific key for each domain.  |
+| `dkim_dns_record_pause:` | 0 | The time (in seconds) the role will pause to show the DNS records with the public keys that must be configured.  |
 
 ### Postfix configuration variables 
 
   Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|
-| `dkim_postfix_config_file:` | /etc/postfix/main.cf | Postfix main configuration file. |
-| `dkim_postfix_config:` | see `vars/main.yml` | list of parameters to be defined in postfix configuration. Default configuration ensures opendkim is set up as a milter of post fix to sign mails. You can define additional postfix parameters using a list union. |
+| `dkim_postfix_config_file:` | /etc/postfix/main.cf | Postfix main configuration file |
+| `dkim_postfix_config:` | see [`vars/main.yml`](vars/main.yml) | List of parameters to be defined in Postfix configuration. Default configuration ensures opendkim is set up as a milter of Postfix to sign mails. You can define additional Postfix parameters using a list union. |
 
 ## Example playbook
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 
 dkim_default_config_file: /etc/default/opendkim
 
-dkim_opendkim_config: /etc/opendkim
+dkim_opendkim_config_dir: /etc/opendkim
 
 dkim_user: opendkim
 dkim_group: opendkim

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,16 @@
 ---
 ## Default Variables for ansible-dkim role
 
+### Opendkim debian/ubuntu package configuration
+
+dkim_default_config_file: /etc/default/opendkim
+
+dkim_opendkim_config: /etc/opendkim
+
+dkim_user: opendkim
+dkim_group: opendkim
+
+### DKIM  configuration variables 
 ## The "selector" for opendkim keys and DNS records generation
 dkim_selector: email
 
@@ -18,3 +28,13 @@ dkim_admin_email: "{{ admin_email | default ( omit ) }}"
 
 ## Whether opendkim uses the same key for all domains or one key per domain
 dkim_same_key: true
+
+## Time, in seconds, that the role will pause to show the publik key DNS records
+dkim_dns_record_pause: 0
+
+dkim_postfix_config_file: /etc/postfix/main.cf
+
+## The parameters to set in postfix configuration
+## Default paramenters, defined in vars/main.yml, configure OPendkim as postfix milter
+dkim_postfix_config: '{{ dkim_postfix_config_default }}'
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,14 @@
 ---
+## DKIM role's handlers
+
 - name: restart opendkim
-  service: name=opendkim state=restarted
+  service: 
+    name: opendkim
+    state: restarted
 
 - name: opendkim - restart postfix
-  service: name=postfix state=restarted
+  service:
+    name: postfix
+    state: restarted
+
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Tomáš Jacík
   company: sunfoxcz
   description: Configure OpenDKIM with Postfix
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9  
   license: MIT
   platforms:
   - name: Ubuntu
@@ -12,6 +12,7 @@ galaxy_info:
     - trusty
     - xenial
     - bionic
+    - focal
   - name: Debian
     versions:
     - jessie

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: dkim
+  author: Tomáš Jacík
+  company: sunfoxcz
+  description: Configure OpenDKIM with Postfix
+  min_ansible_version: 2.4
+  license: MIT
+  platforms:
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+    - bionic
+  - name: Debian
+    versions:
+    - jessie
+    - stretch
+    - buster
+  galaxy_tags:
+    - mail
+    - DKIM
+    - antispam
+    - postfix
+    - opendkim
+dependencies: []

--- a/tasks/dns_records.yml
+++ b/tasks/dns_records.yml
@@ -1,25 +1,17 @@
 ---
 ## Show the DNS records to configure with dkim publik key
 
-- name: find files with DNS records with public keys
-  find:
-    path: /etc/opendkim/keys
-    patterns: '{{ dkim_selector }}.txt'
-    recurse: yes
-  register: dkim_txt_files
-
 - name: extract found files content
   slurp:
-    src: '{{ dkim_txt_file.path }}'
-  loop: '{{ dkim_txt_files.files }}'
-  loop_control:
-    loop_var: dkim_txt_file
-  register: dkim_dns_records
+    src: "/etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.txt"
+  register: dkim_dns_record
 
-- name: show DNS records in dkim_selector.txt files
-  debug: 
-    msg: 
-    - 'You must add to your DNS the following records:'
-    - "{{ dkim_dns_records.results | json_query ('[*].content') | map('b64decode') | list  }}"
+- pause:
+    seconds: 1
+    prompt: |
+      ################################################################################################
+      DNS record to add for zone {{ dkim_domain }}:
+      {{ dkim_dns_record.content | string | b64decode }}
+      ################################################################################################
 
 ...

--- a/tasks/dns_records.yml
+++ b/tasks/dns_records.yml
@@ -1,13 +1,14 @@
 ---
 ## Show the DNS records to configure with dkim publik key
 
-- name: extract found files content
+- name: extract DKIM public key DNS record
   slurp:
     src: "/etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.txt"
   register: dkim_dns_record
 
-- pause:
-    seconds: 1
+- name: display DKIM public key DNS record
+  pause:
+    seconds: '{{ dkim_dns_record_pause }}'
     prompt: |
       ################################################################################################
       DNS record to add for zone {{ dkim_domain }}:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,4 +15,9 @@
 
 - import_tasks: postfix.yml
 
-- import_tasks: dns_records.yml
+- include_tasks: dns_records.yml
+  loop: '{{ dkim_domains }}'
+  loop_control:
+    loop_var: dkim_domain
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - import_tasks: postfix.yml
 
 - include_tasks: dns_records.yml
-  loop: '{{ dkim_domains }}'
+  loop: '{{ dkim_domains if dkim_domains is defined else [] }}'
   loop_control:
     loop_var: dkim_domain
 

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -42,7 +42,7 @@
   include_tasks: opendkim_keys.yml 
   loop: '{{ [ dkim_domains[0] ] if dkim_same_key else dkim_domains }}'
   loop_control:
-    loop_var: domain
+    loop_var: dkim_domain
 
 - name: opendkim is running
   service: name=opendkim state=started enabled=yes

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -18,13 +18,13 @@
 
 - name: opendkim directory present
   file: 
-    path: '{{ dkim_opendkim_config }}/keys' 
+    path: '{{ dkim_opendkim_config_dir }}/keys' 
     state: directory
 
 - name: opendkim TrustedHosts present
   copy: 
     src: TrustedHosts
-    dest: '{{ dkim_opendkim_config }}/TrustedHosts'
+    dest: '{{ dkim_opendkim_config_dir }}/TrustedHosts'
   notify:
    - restart opendkim
 
@@ -38,14 +38,14 @@
 - name: opendkim KeyTable is configured
   template:
     src: KeyTable.j2
-    dest: '{{ dkim_opendkim_config }}/KeyTable'
+    dest: '{{ dkim_opendkim_config_dir }}/KeyTable'
   notify:
    - restart opendkim
 
 - name: opendkim SigningTable is configured
   template:
     src: SigningTable.j2
-    dest: '{{ dkim_opendkim_config }}/SigningTable'
+    dest: '{{ dkim_opendkim_config_dir }}/SigningTable'
   notify:
    - restart opendkim
 

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -1,4 +1,5 @@
 ---
+## Opendkin configuration tasks
 
 - name: opendkim packages are installed
   apt:
@@ -9,40 +10,55 @@
 
 - name: opendkim socket configured
   lineinfile:
-    dest: /etc/default/opendkim
+    dest: "{{ dkim_default_config_file }}"
     regexp: '^SOCKET='
     line: 'SOCKET="inet:12301@localhost"'
   notify:
    - restart opendkim
 
 - name: opendkim directory present
-  file: path=/etc/opendkim/keys state=directory
+  file: 
+    path: '{{ dkim_opendkim_config }}/keys' 
+    state: directory
 
 - name: opendkim TrustedHosts present
-  copy: src=TrustedHosts dest=/etc/opendkim/TrustedHosts
+  copy: 
+    src: TrustedHosts
+    dest: '{{ dkim_opendkim_config }}/TrustedHosts'
   notify:
    - restart opendkim
 
 - name: opendkim is configured
-  template: src=opendkim.conf.j2 dest=/etc/opendkim.conf
+  template: 
+    src: opendkim.conf.j2
+    dest: /etc/opendkim.conf
   notify:
    - restart opendkim
 
 - name: opendkim KeyTable is configured
-  template: src=KeyTable.j2 dest=/etc/opendkim/KeyTable
+  template:
+    src: KeyTable.j2
+    dest: '{{ dkim_opendkim_config }}/KeyTable'
   notify:
    - restart opendkim
 
 - name: opendkim SigningTable is configured
-  template: src=SigningTable.j2 dest=/etc/opendkim/SigningTable
+  template:
+    src: SigningTable.j2
+    dest: '{{ dkim_opendkim_config }}/SigningTable'
   notify:
    - restart opendkim
 
 - name: generate opendkim keys
   include_tasks: opendkim_keys.yml 
-  loop: '{{ [ dkim_domains[0] ] if dkim_same_key else dkim_domains }}'
+  loop: '{{ ( [ dkim_domains[0] ] if dkim_same_key else dkim_domains ) if dkim_domains is defined else [] }}'
   loop_control:
     loop_var: dkim_domain
 
 - name: opendkim is running
-  service: name=opendkim state=started enabled=yes
+  service: 
+    name: opendkim
+    state: started
+    enabled: yes
+
+...

--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -3,24 +3,24 @@
 
 - name: creates domain's keys directory
   file: 
-    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}"
+    path: "{{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}"
     state: directory
 
 - name: ensure signing key is present
   stat: 
-    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
+    path: "{{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
     get_md5: no
   register: dkim_key
 
 - name: generate signing key
-  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D {{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
+  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D {{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
   when: not dkim_key.stat.exists
   notify:
   - restart opendkim
 
 - name: ensure signing key owner
   file:
-    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
+    path: "{{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
     owner: '{{ dkim_user }}'
     group: '{{ dkim_group }}'
 

--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -1,26 +1,27 @@
 ---
 ## Loop to generate keys for each domain
+
 - name: creates domain's keys directory
   file: 
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
+    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}"
     state: directory
 
 - name: ensure signing key is present
   stat: 
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private
+    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
     get_md5: no
   register: dkim_key
 
 - name: generate signing key
-  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
+  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D {{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
   when: not dkim_key.stat.exists
   notify:
   - restart opendkim
 
 - name: ensure signing key owner
   file:
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private
-    owner: opendkim 
-    group: opendkim
+    path: "{{ dkim_opendkim_config }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
+    owner: '{{ dkim_user }}'
+    group: '{{ dkim_group }}'
 
 ...

--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -2,24 +2,24 @@
 ## Loop to generate keys for each domain
 - name: creates domain's keys directory
   file: 
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
     state: directory
 
 - name: ensure signing key is present
   stat: 
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}/{{ dkim_selector }}.private
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private
     get_md5: no
   register: dkim_key
 
 - name: generate signing key
-  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ domain }} -D /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}
+  shell: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
   when: not dkim_key.stat.exists
   notify:
   - restart opendkim
 
 - name: ensure signing key owner
   file:
-    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ domain }}/{{ dkim_selector }}.private
+    path: /etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private
     owner: opendkim 
     group: opendkim
 

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -1,4 +1,5 @@
 ---
+## Postfix configuration for OpenDKIM messages signing integration
 
 - name: postfix is installed
   apt:
@@ -6,26 +7,22 @@
     state: present
   tags: postfix
 
-- name: postfix milter_protocol is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^milter_protocol line="milter_protocol = 6"
-  notify:
-   - opendkim - restart postfix
-
-- name: postfix milter_default_action is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^milter_default_action line="milter_default_action = accept"
-  notify:
-   - opendkim - restart postfix
-
-- name: postfix smtpd_milters is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^smtpd_milters line="smtpd_milters = inet:localhost:12301"
-  notify:
-   - opendkim - restart postfix
-
-- name: postfix non_smtpd_milters is configured
-  lineinfile: dest=/etc/postfix/main.cf regexp=^non_smtpd_milters line="non_smtpd_milters = inet:localhost:12301"
-  notify:
-   - opendkim - restart postfix
+- name: opendkim configuration as a postfix milter
+  lineinfile:
+    path: '{{ dkim_postfix_config_file }}'
+    regexp: "^{{ dkim_postfix_config_line.parameter }}"
+    line: "{{ dkim_postfix_config_line.parameter }} = {{ dkim_postfix_config_line.value }}"
+    backup: yes
+  loop: "{{ dkim_postfix_config }}"
+  loop_control:
+    loop_var: dkim_postfix_config_line
+  tags: postfix
 
 - name: postfix is running
-  service: name=postfix state=started enabled=yes
+  service: 
+    name: postfix 
+    state: started
+    enabled: yes
   tags: postfix
+
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# DKIM ANsible role vars
+
+dkim_postfix_config_default: 
+- parameter: milter_protocol
+  value: 6
+- parameter: milter_default_action
+  value: accept
+- parameter: smtpd_milters
+  value: inet:localhost:12301
+- parameter: non_smtpd_milters
+  value: inet:localhost:12301
+
+...


### PR DESCRIPTION
Hello @foxycode,
As [requested in PR #5](https://github.com/FoxyRoles/ansible-dkim/pull/5#issuecomment-636480878) here a proposal to solve the same functionnalities without `json_query` filter that requires `jmespath`. 
I tried cat but outputs were not nice. For the loops I came back to the keys definition approach, and after searching and trying, I agree with [this post](https://stackoverflow.com/a/56391268) that the `pause` module is the best way to have an Ansible playbooks' human's friendly output.

By the way, maybe the role requires:
- some more documentation, particularly describing the DNS configuration associated with an opendkim instance, as well as some variables options description. 
- parametrisation of several values that are hardcoded in tasks (such as /etc/opendkim folder and subfolders)

And, proposal: for module parameters, the syntaxis `parameter1=value1 parameter2=value2` is mainly intended for ad-hoc commands. For playbooks and roles, I think is more readable to have the YAML syntax. ¿Do you agree to re-write the role with the latter syntax?  