### PR TITLE
RSA keylength, keys directory permissions, remove pause module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ See also comments and default values in role's file [`default/main.yml`](default
 | `dkim_admin_email:` | none | e-mail address that manages Opendkim. You must define either `dkim_admin_email` or legacy `admin_email`. |
 | `dkim_domains:` | none | List of domains that Opendkim must be configured to sign the mails of. A yaml list of DNS. |
 | `dkim_same_key:` | true | Whether Opendkim must generate and use the same key for all domains or one specific key for each domain.  |
-| `dkim_dns_record_pause:` | 0 | The time (in seconds) the role will pause to show the DNS records with the public keys that must be configured.  |
+<!--- | `dkim_dns_record_pause:` | 0 | The time (in seconds) the role will pause to show the DNS records with the public keys that must be configured.  | -->
+| `dkim_rsa_keylen:` | 2048 | RSA keylength when generating keys with `opendkim-keygen`. Other currently possible options are 1024 or 4096.  |
 
 ### Postfix configuration variables 
 
@@ -51,7 +52,7 @@ See also comments and default values in role's file [`default/main.yml`](default
 ---
 - hosts: myserver
   roles:
-    - role: sunfoxcz.dkim
+    - role: FoxyRoles.ansible-dkim
       # if admin_email variable is present, will be used as default for dkim_admin_email
       dkim_admin_email: my@mail.tld
       dkim_selector: mail

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ See also comments and default values in role's file [`default/main.yml`](default
 | `dkim_admin_email:` | none | e-mail address that manages Opendkim. You must define either `dkim_admin_email` or legacy `admin_email`. |
 | `dkim_domains:` | none | List of domains that Opendkim must be configured to sign the mails of. A yaml list of DNS. |
 | `dkim_same_key:` | true | Whether Opendkim must generate and use the same key for all domains or one specific key for each domain.  |
-<!--- | `dkim_dns_record_pause:` | 0 | The time (in seconds) the role will pause to show the DNS records with the public keys that must be configured.  | -->
 | `dkim_rsa_keylen:` | 2048 | RSA keylength when generating keys with `opendkim-keygen`. Other currently possible options are 1024 or 4096.  |
 
 ### Postfix configuration variables 
@@ -52,7 +51,7 @@ See also comments and default values in role's file [`default/main.yml`](default
 ---
 - hosts: myserver
   roles:
-    - role: FoxyRoles.ansible-dkim
+    - role: sunfoxcz.dkim
       # if admin_email variable is present, will be used as default for dkim_admin_email
       dkim_admin_email: my@mail.tld
       dkim_selector: mail

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,9 +33,6 @@ dkim_same_key: true
 ## Other currently possible keylengths: 1024 or 4096.
 dkim_rsa_keylen: 2048
 
-## Time, in seconds, that the role will pause to show the publik key DNS records
-dkim_dns_record_pause: 0
-
 ## Select your MTA (postfix or sendmail)
 dkim_mta: postfix
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,10 @@ dkim_admin_email: "{{ admin_email | default ( omit ) }}"
 ## Whether opendkim uses the same key for all domains or one key per domain
 dkim_same_key: true
 
+## When generating key with opendkim-gkeygen, default RSA keylen is 2048
+## Other currently possible keylengths: 1024 or 4096.
+dkim_rsa_keylen: 2048
+
 ## Time, in seconds, that the role will pause to show the publik key DNS records
 dkim_dns_record_pause: 0
 

--- a/tasks/dns_records.yml
+++ b/tasks/dns_records.yml
@@ -3,16 +3,24 @@
 
 - name: extract DKIM public key DNS record
   slurp:
-    src: "/etc/opendkim/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.txt"
+    src: "{{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.txt"
   register: dkim_dns_record
 
 - name: display DKIM public key DNS record
-  pause:
-    seconds: '{{ dkim_dns_record_pause }}'
-    prompt: |
+  debug:
+    msg: |
       ################################################################################################
       DNS record to add for zone {{ dkim_domain }}:
       {{ dkim_dns_record.content | string | b64decode }}
       ################################################################################################
+
+  # Pause module causes role to fail: https://github.com/FoxyRoles/ansible-dkim/issues/10
+  # pause:
+  #   seconds: '{{ dkim_dns_record_pause }}'
+  #   prompt: |
+  #     ################################################################################################
+  #     DNS record to add for zone {{ dkim_domain }}:
+  #     {{ dkim_dns_record.content | string | b64decode }}
+  #     ################################################################################################
 
 ...

--- a/tasks/dns_records.yml
+++ b/tasks/dns_records.yml
@@ -14,13 +14,4 @@
       {{ dkim_dns_record.content | string | b64decode }}
       ################################################################################################
 
-  # Pause module causes role to fail: https://github.com/FoxyRoles/ansible-dkim/issues/10
-  # pause:
-  #   seconds: '{{ dkim_dns_record_pause }}'
-  #   prompt: |
-  #     ################################################################################################
-  #     DNS record to add for zone {{ dkim_domain }}:
-  #     {{ dkim_dns_record.content | string | b64decode }}
-  #     ################################################################################################
-
 ...

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -20,6 +20,8 @@
   file: 
     path: '{{ dkim_opendkim_config_dir }}/keys' 
     state: directory
+    group: "{{ dkim_group }}"
+    mode: 0750
 
 - name: opendkim TrustedHosts present
   copy: 

--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -13,7 +13,7 @@
   register: dkim_key
 
 - name: generate signing key
-  command: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domain }} -D {{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
+  command: opendkim-genkey -b {{ dkim_rsa_keylen }} -s {{ dkim_selector }} -d {{ dkim_domain }} -D {{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}
   when: not dkim_key.stat.exists
   notify:
   - restart opendkim


### PR DESCRIPTION
Referring to the following opened issues:
- https://github.com/FoxyRoles/ansible-dkim/issues/9
- https://github.com/FoxyRoles/ansible-dkim/issues/10
- https://github.com/FoxyRoles/ansible-dkim/issues/11

Proposals:
- create variable `dkim_rsa_keylen` that allows to set a custom length for the generated RSA key
- use `debug` module instead of `pause` to print public key/DNS TXT record to screen
- ensure ownership by `opendkim` (or group set in `dkim_group` variable) of the `../keys/`  directory, in order for `opendkim` to be able to read the private key file