### PR TITLE
switch from debian/ubuntu specific apt-get to OS agnostic ansible.builtin.package (to make it work both for apt and yum-based distros)

### DIFF
--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -2,10 +2,10 @@
 ## Opendkin configuration tasks
 
 - name: opendkim packages are installed
-  apt:
-    pkg:
-    - opendkim
-    - opendkim-tools
+  ansible.builtin.package:
+    name:
+      - opendkim
+      - opendkim-tools
     state: present
 
 - name: opendkim socket configured

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -3,9 +3,8 @@
 
 - name: postfix is installed
   ansible.builtin.package:
-    name:
-      - postfix
-  state: present
+    name: postfix
+    state: present
   tags: postfix
 
 - name: opendkim configuration as a postfix milter

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -2,9 +2,10 @@
 ## Postfix configuration for OpenDKIM messages signing integration
 
 - name: postfix is installed
-  apt:
-    pkg: postfix
-    state: present
+  ansible.builtin.package:
+    name:
+      - postfix
+  state: present
   tags: postfix
 
 - name: opendkim configuration as a postfix milter

--- a/tasks/sendmail.yml
+++ b/tasks/sendmail.yml
@@ -2,8 +2,8 @@
 ##  sendmail configuration for OpenDKIM messages signing integration
 
 - name: sendmail is installed
-  apt:
-    pkg: sendmail
+  ansible.builtin.package:
+    name: sendmail
     state: present
   tags: sendmail
 

--- a/tasks/sendmail.yml
+++ b/tasks/sendmail.yml
@@ -7,7 +7,6 @@
     state: present
   tags: sendmail
 
-
 - name: opendkim configuration as a sendmail filter
   lineinfile:
     path: '{{ dkim_sendmail_config_file }}'


### PR DESCRIPTION
We're testing this on RHEL, and everyting seems to work, except for the apt-get parts, where the packages are installed. Switching from apt: pkg: to ansible.builtin.package makes it work for "everybody".

This is my very first merge request, if something is missing, or thinsg need to be done differently, please let me know.

The above-mentioned changes work here.