### PR TITLE
change from debian-specific apt to generic ansible "package"

### DIFF
--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -2,10 +2,10 @@
 ## Opendkin configuration tasks
 
 - name: opendkim packages are installed
-  apt:
-    pkg:
-    - opendkim
-    - opendkim-tools
+  package:
+    name:
+      - opendkim
+      - opendkim-tools
     state: present
 
 - name: opendkim socket configured

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -2,8 +2,8 @@
 ## Postfix configuration for OpenDKIM messages signing integration
 
 - name: postfix is installed
-  apt:
-    pkg: postfix
+  package:
+    name: postfix
     state: present
   tags: postfix
 

--- a/tasks/sendmail.yml
+++ b/tasks/sendmail.yml
@@ -2,8 +2,8 @@
 ##  sendmail configuration for OpenDKIM messages signing integration
 
 - name: sendmail is installed
-  apt:
-    pkg: sendmail
+  package:
+    name: sendmail
     state: present
   tags: sendmail
 


### PR DESCRIPTION
using this, the ansible scripts also work on our RHEL servers.
As discussed yesterday, I hope this pull request is better:
- using package now
- the three changes in one commit

Again: first time. Please comment if something else is needed.
