### PR TITLE
Upgrade task to use `get_checksum` instead of deprecated `get_md5`

### DIFF
--- a/tasks/opendkim_keys.yml
+++ b/tasks/opendkim_keys.yml
@@ -9,7 +9,7 @@
 - name: ensure signing key is present
   stat: 
     path: "{{ dkim_opendkim_config_dir }}/keys{{ '' if dkim_same_key else '/' ~ dkim_domain }}/{{ dkim_selector }}.private"
-    get_md5: no
+    get_checksum: false
   register: dkim_key
 
 - name: generate signing key


### PR DESCRIPTION
When running on the stable version of ansible, I got the following error:

```
TASK [sunfoxcz.dkim : ensure signing key is present] *******************************************************************
fatal: [hostname]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (stat) module: get_md5. Supported parameters include: checksum_algorithm, follow, get_attributes, get_checksum, get_mime, path (attr, attributes, checksum, checksum_algo, dest, mime, mime-type, mime_type, name)."}
```

After looking online for the error, I found this occurrence for a similar case:

https://github.com/geerlingguy/ansible-role-swap/issues/32

Seems like `get_md5` is deprecated, so this change modifies it to use `get_checksum`.