### PR TITLE
implement dkim_conf_override to allow additional manual settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See also comments and default values in role's file [`default/main.yml`](default
 | `dkim_domains:` | none | List of domains that Opendkim must be configured to sign the mails of. A yaml list of DNS. |
 | `dkim_same_key:` | true | Whether Opendkim must generate and use the same key for all domains or one specific key for each domain.  |
 | `dkim_rsa_keylen:` | 2048 | RSA keylength when generating keys with `opendkim-keygen`. Other currently possible options are 1024 or 4096.  |
+| `dkim_conf_override:` | empty | Additional config inserted into /etc/opendkim.conf, such as "Nameservers 127.0.0.1". |
 
 ### Postfix configuration variables
 

--- a/templates/opendkim.conf.j2
+++ b/templates/opendkim.conf.j2
@@ -20,3 +20,5 @@ SignatureAlgorithm      rsa-sha256
 UserID                  opendkim:opendkim
 
 Socket                  inet:12301@localhost
+
+{{ dkim_conf_override | default('') }}


### PR DESCRIPTION
dkim_conf_override implemented in /etc/opendkim.conf to allow additional manual settings outside automated ansible-dkim flow

You may need to do this if your system is firewalled from being able to talk to DNS port 53 on the internet and is expected to talk to local resolvers instead.  This in particular isn't subject to the usual caveats regarding "but your DNS won't be secure!" if this is just for an outbound email server that is DKIM signing its own email going out to an upstream SMTP relay (but I haven't included such a description in README.md).  Of course you're also free to put whatever configuration in here that isn't covered by the default ansible-dkim template.

Fixes #28 .